### PR TITLE
Fix vertical spacing for home page cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
         </div>
 
         <!-- Navigation Cards -->
-        <div class="row">
+        <div class="row gy-4">
             <div class="col-md-4">
                 <div class="nav-card">
                     <div class="nav-card-icon documents">


### PR DESCRIPTION
## Summary
- add Bootstrap `gy-4` class to row of cards so spacing appears when stacked on small screens

## Testing
- `python3 -m py_compile adpnote.py fscpanel.py`

------
https://chatgpt.com/codex/tasks/task_e_68786c5a9aa08333a10fd22b97ab4573