### PR TITLE
fix: Add margin to stacked cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,9 @@
             }
             .nav-card {
                 padding: 1.5rem;
-                margin-bottom: 1.5rem;
+            }
+            .col-md-4 {
+                margin-top: 1.5rem;
             }
             .resource-banner {
                 padding: 1.5rem;


### PR DESCRIPTION
On mobile devices, the three horizontally aligned cards become vertically stacked. This change adds a margin between the cards to prevent them from being too close together in the mobile view.